### PR TITLE
PR for #1: Add useClickOutside hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
     - This custom hook can be used as a BackHandler hook in React native Android for adding and removing event handlers 
 ### useScrollIntoViewHook
     - This custom hook can be used as a reusable hook to scroll to an element in the view
+### useClickOutside
+    - This custom hook can be used as a reusable hook to detect when a click happens outside of a component
 
 
 

--- a/src/hooks/useClickOutside/useClickOutside.js
+++ b/src/hooks/useClickOutside/useClickOutside.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+const useOutsideClick = (ref, callback) => {
+  const handleClick = e => {
+    if (ref.current && !ref.current.contains(e.target)) {
+      callback();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick);
+
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  });
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
Hello 👋,

This hook can be useful when you want to close a menu/dropdown or any kind of component when you click outside or away from it.